### PR TITLE
Fix broken HTML parser and include header

### DIFF
--- a/Parsing_HTML.bash
+++ b/Parsing_HTML.bash
@@ -18,8 +18,26 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-mostrar_demo 
+SITE="$1"
 
-SITE=$1
+mostrar_demo
 
-echo "🔍 Extraindo domínios do site $SI
+echo "🔍 Baixando HTML de $SITE..."
+HTML=$(curl -sL "$SITE")
+
+DOMINIOS=$(echo "$HTML" | grep -Eo "https?://[^/\"']+" | sed -E 's#https?://##' | cut -d/ -f1 | sort -u)
+
+if [ -z "$DOMINIOS" ]; then
+    echo "❌ Nenhum domínio encontrado no HTML."
+    exit 1
+fi
+
+echo "🌐 Domínios encontrados:" 
+for d in $DOMINIOS; do
+    IP=$(dig +short "$d" | head -n 1)
+    if [ -n "$IP" ]; then
+        echo "   $d -> $IP"
+    else
+        echo "   $d -> IP não encontrado"
+    fi
+done

--- a/dns_resolver.c
+++ b/dns_resolver.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <unistd.h>
 
 #define TAM_MAX 256
 


### PR DESCRIPTION
## Summary
- fix invalid Parsing_HTML.bash script
- add missing `<unistd.h>` include in dns_resolver.c

## Testing
- `bash -n Parsing_HTML.bash PortKnocking.bash portscan.bash discovery.bash dnsreverse.bash dnszone.bash pesquisa.bash subtakeover.bash webrecon.bash`
- `gcc -Wall -Wextra -o /tmp/dns_resolver dns_resolver.c`

------
https://chatgpt.com/codex/tasks/task_e_68461458034483328c14f0d1e81946cb