### PR TITLE
Improve error handling across network utilities

### DIFF
--- a/socket_utils.py
+++ b/socket_utils.py
@@ -1,14 +1,19 @@
 import socket
 
 def verifica_porta(ip, porta):
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as meu_socket:
-        meu_socket.settimeout(5)  # Definir um timeout para evitar longos tempos de espera
-        conexao = meu_socket.connect_ex((ip, porta))
-        
-        if conexao == 0:
-            print(f"Porta {porta} no IP {ip} está Aberta")
-        else:
-            print(f"Porta {porta} no IP {ip} está Fechada")
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as meu_socket:
+            meu_socket.settimeout(5)  # Definir um timeout para evitar longos tempos de espera
+            conexao = meu_socket.connect_ex((ip, porta))
+
+            if conexao == 0:
+                print(f"Porta {porta} no IP {ip} está Aberta")
+            else:
+                print(f"Porta {porta} no IP {ip} está Fechada")
+    except socket.timeout:
+        print(f"Tempo de conexão esgotado ao verificar a porta {porta} em {ip}.")
+    except OSError as erro:
+        print(f"Erro ao verificar a porta {porta} em {ip}: {erro}")
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
## Summary
- make the Python port scanner surface network and permission errors instead of hiding them
- harden the C DNS resolver against invalid input and name resolution failures
- wrap the reusable socket utility in defensive timeout and OS error handling

## Testing
- python3 -m compileall portscan.py socket_utils.py
- gcc dns_resolver.c -o dns_resolver


------
https://chatgpt.com/codex/tasks/task_e_68e6f34f74c48332b82f463df5d90861